### PR TITLE
  Our created_at times in avro messages are using string types. We wa…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -266,6 +266,7 @@ public abstract class DbDialect {
       case "mysql":
         return new MySqlDialect();
       case "postgresql":
+      case "redshift":
         return new PostgreSqlDialect();
       default:
         return new GenericDialect();


### PR DESCRIPTION
…nt to insert these into Redshift as a timestamp type. The Schema.type() case statement below specifically sends all strings with setString()

  This case statement is a hack to short circuit "magic" field names that we know we want to parse
  into timestamps. Otherwise we'd be having to test every string to see if its a timestamp.
  If we do detect a timestamp for this field, we want to return and skip the next case statement.